### PR TITLE
Actually return the scan result

### DIFF
--- a/openscap-container-entrypoint.sh
+++ b/openscap-container-entrypoint.sh
@@ -38,4 +38,7 @@ cmd+=($CONTENT)
 # picks up the whole thing and not a partial file
 echo "Running oscap-chroot as ${cmd[@]}"
 "${cmd[@]}"
+rv=$?
+echo "The scanner returned $rv"
 test -f /tmp/report.xml && mv /tmp/report.xml $REPORT_DIR
+exit $rv


### PR DESCRIPTION
The scan result was not returned, because afterwards we also ran mv to
get the scan results atomically, so the exit code actually came from the
mv return code.